### PR TITLE
Add n8n workflow for automated 45s video production

### DIFF
--- a/flows/video_45s_automation.json
+++ b/flows/video_45s_automation.json
@@ -1,0 +1,532 @@
+{
+  "name": "Video 45s - Form to Automated Production",
+  "nodes": [
+    {
+      "parameters": {
+        "path": "brief-video-45s",
+        "formTitle": "Brief para video automatizado de 45s",
+        "formDescription": "Ingresa el guion y sube logo + avatar para generar el video final.",
+        "responseMode": "onReceived",
+        "options": {
+          "allowMultipleSubmissions": false,
+          "fields": [
+            {
+              "fieldLabel": "Guion",
+              "fieldName": "script",
+              "type": "textarea",
+              "required": true,
+              "placeholder": "Pega el guion completo del video"
+            },
+            {
+              "fieldLabel": "Logo",
+              "fieldName": "logo",
+              "type": "file",
+              "required": true,
+              "description": "Sube el logo en PNG o SVG con fondo transparente"
+            },
+            {
+              "fieldLabel": "Avatar",
+              "fieldName": "avatar",
+              "type": "file",
+              "required": true,
+              "description": "Sube un retrato del portavoz a utilizar"
+            }
+          ]
+        }
+      },
+      "id": "FormTrigger",
+      "name": "Formulario Brief",
+      "type": "n8n-nodes-base.formTrigger",
+      "typeVersion": 1,
+      "position": [
+        -600,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const rawScript = $json.script?.value || $json.script;\nreturn [{\n  script: {\n    raw: rawScript,\n    cleaned: rawScript.trim().replace(/\\s+/g, ' '),\n    targetDurationSeconds: 45,\n    segments: 3\n  },\n  assets: {\n    logo: $binary.logo,\n    avatar: $binary.avatar\n  }\n}];"
+      },
+      "id": "NormalizeInput",
+      "name": "Normalizar Entradas",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        -340,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "chat",
+        "model": "gpt-4.1-mini",
+        "systemMessage": "Eres un director creativo. Divide el guion en escenas coherentes para un video de 45 segundos. Devuelve JSON con \"scenes\": [ {\"order\":1,\"start\":0,\"end\":15,\"prompt\":\"...\",\"overlayText\":\"...\" } ]. Asegúrate de que cada escena use elementos del guion e incluya instrucciones para integrar logo y avatar cuando sea relevante.",
+        "messages": [
+          {
+            "text": "Guion:\n{{$json[\"script\"][\"cleaned\"]}}\nDuración objetivo: {{$json[\"script\"][\"targetDurationSeconds\"]}} segundos",
+            "type": "user"
+          }
+        ],
+        "additionalFields": {
+          "responseFormat": "json"
+        }
+      },
+      "id": "StoryboardLLM",
+      "name": "Storyboard IA",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 1,
+      "position": [
+        -120,
+        200
+      ],
+      "credentials": {
+        "openAiApi": {
+          "id": "{{OPENAI_API_CREDENTIAL_ID}}",
+          "name": "OpenAI Account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "functionCode": "const scenes = Array.isArray($json.data?.scenes) ? $json.data.scenes : [];\nreturn scenes.map(scene => ({\n  scene,\n  script: $items(0)[0].json.script,\n  assets: $items(0)[0].json.assets\n}));"
+      },
+      "id": "ExpandScenes",
+      "name": "Expandir Escenas",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        120,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "fieldToSplitOut": "scene"
+      },
+      "id": "SplitScenes",
+      "name": "Iterar Escenas",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 1,
+      "position": [
+        340,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "headerAuth",
+        "url": "https://api.openai.com/v1/images/generations",
+        "responseFormat": "json",
+        "options": {
+          "batchSize": 1
+        },
+        "headerParametersUi": {
+          "parameter": [
+            {
+              "name": "Authorization",
+              "value": "Bearer {{ $credentials.openAiApi.apiKey }}"
+            }
+          ]
+        },
+        "bodyParametersUi": {
+          "parameter": [
+            {
+              "name": "model",
+              "value": "gpt-image-1"
+            },
+            {
+              "name": "prompt",
+              "value": "{{$json.scene.prompt}}. Incluir espacio para overlay de logo y avatar cuando se indique. Estilo cinematográfico, 16:9, video frame."
+            },
+            {
+              "name": "size",
+              "value": "1792x1024"
+            },
+            {
+              "name": "n",
+              "value": "1"
+            }
+          ]
+        }
+      },
+      "id": "GenerateSceneImage",
+      "name": "Generar Imagen Escena",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [
+        560,
+        80
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "{{OPENAI_HEADER_AUTH_ID}}",
+          "name": "OpenAI Header"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "options": {},
+        "sourceKey": "data[0].b64_json",
+        "destinationKey": "sceneImage",
+        "encoding": "base64"
+      },
+      "id": "DecodeSceneImage",
+      "name": "Decodificar Imagen",
+      "type": "n8n-nodes-base.moveBinaryData",
+      "typeVersion": 1,
+      "position": [
+        780,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const scene = $json.scene;\nconst duration = (scene.end - scene.start) || 15;\nreturn [{\n  scene,\n  duration,\n  overlayText: scene.overlayText,\n  image: $binary.sceneImage,\n  script: $json.script,\n  assets: $json.assets\n}];"
+      },
+      "id": "AssembleScenePayload",
+      "name": "Preparar Payload Escena",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "wait",
+        "join": "keepKeyMatches",
+        "propertyName": "scene.order"
+      },
+      "id": "MergeScenes",
+      "name": "Unir Escenas",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 2,
+      "position": [
+        1220,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "headerAuth",
+        "options": {
+          "response": "file"
+        },
+        "url": "https://api.openai.com/v1/audio/speech",
+        "method": "POST",
+        "headerParametersUi": {
+          "parameter": [
+            {
+              "name": "Authorization",
+              "value": "Bearer {{ $credentials.openAiApi.apiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "bodyParametersJson": "{\n  \"model\": \"gpt-4o-mini-tts\",\n  \"voice\": \"alloy\",\n  \"input\": \"{{$json.script.cleaned}}\",\n  \"format\": \"mp3\"\n}"
+      },
+      "id": "VoiceOver",
+      "name": "Generar Voz en Off",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [
+        -120,
+        -40
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "{{OPENAI_HEADER_AUTH_ID}}",
+          "name": "OpenAI Header"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "none",
+        "url": "https://pixabay.com/api/sounds/",
+        "options": {},
+        "queryParametersUi": {
+          "parameter": [
+            {
+              "name": "key",
+              "value": "={{$credentials.pixabayApi.apiKey}}"
+            },
+            {
+              "name": "q",
+              "value": "corporate background music"
+            },
+            {
+              "name": "order",
+              "value": "popular"
+            },
+            {
+              "name": "min_duration",
+              "value": "40"
+            },
+            {
+              "name": "max_duration",
+              "value": "60"
+            }
+          ]
+        }
+      },
+      "id": "SearchMusic",
+      "name": "Buscar Musica",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [
+        -120,
+        -260
+      ],
+      "credentials": {
+        "pixabayApi": {
+          "id": "{{PIXABAY_API_CREDENTIAL_ID}}",
+          "name": "Pixabay"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "functionCode": "const hit = $json.hits?.[0];\nif (!hit) { throw new Error('No se encontró pista en Pixabay'); }\nreturn [{ downloadUrl: hit.audio, duration: hit.duration }];"
+      },
+      "id": "SelectMusic",
+      "name": "Seleccionar Pista",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        120,
+        -260
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "none",
+        "url": "={{$json.downloadUrl}}",
+        "options": {
+          "response": "file"
+        }
+      },
+      "id": "DownloadMusic",
+      "name": "Descargar Musica",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [
+        340,
+        -260
+      ]
+    },
+    {
+      "parameters": {
+        "command": "./scripts/render_video.sh",
+        "arguments": "{{$json}}",
+        "options": {
+          "output": "file"
+        }
+      },
+      "id": "RenderVideo",
+      "name": "Renderizar Video",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [
+        1440,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "binary",
+        "options": {
+          "binaryPropertyName": "video"
+        },
+        "propertyName": "data"
+      },
+      "id": "ReturnResponse",
+      "name": "Entregar Video",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [
+        1660,
+        200
+      ]
+    }
+  ],
+  "connections": {
+    "Formulario Brief": {
+      "main": [
+        [
+          {
+            "node": "Normalizar Entradas",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalizar Entradas": {
+      "main": [
+        [
+          {
+            "node": "Storyboard IA",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Generar Voz en Off",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Buscar Musica",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Storyboard IA": {
+      "main": [
+        [
+          {
+            "node": "Expandir Escenas",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Expandir Escenas": {
+      "main": [
+        [
+          {
+            "node": "Iterar Escenas",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Iterar Escenas": {
+      "main": [
+        [
+          {
+            "node": "Generar Imagen Escena",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Unir Escenas",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generar Imagen Escena": {
+      "main": [
+        [
+          {
+            "node": "Decodificar Imagen",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Decodificar Imagen": {
+      "main": [
+        [
+          {
+            "node": "Preparar Payload Escena",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Preparar Payload Escena": {
+      "main": [
+        [
+          {
+            "node": "Unir Escenas",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generar Voz en Off": {
+      "main": [
+        [
+          {
+            "node": "Renderizar Video",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Descargar Musica": {
+      "main": [
+        [
+          {
+            "node": "Renderizar Video",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Unir Escenas": {
+      "main": [
+        [
+          {
+            "node": "Renderizar Video",
+            "type": "main",
+            "index": 2
+          }
+        ]
+      ]
+    },
+    "Renderizar Video": {
+      "main": [
+        [
+          {
+            "node": "Entregar Video",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Buscar Musica": {
+      "main": [
+        [
+          {
+            "node": "Seleccionar Pista",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Seleccionar Pista": {
+      "main": [
+        [
+          {
+            "node": "Descargar Musica",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "versionId": "53b9ce6f-f38e-4c26-9198-2ae13f6f0151"
+}

--- a/flows/video_45s_automation.md
+++ b/flows/video_45s_automation.md
@@ -1,0 +1,93 @@
+# Flujo n8n: Formulario a video automatizado de 45 segundos
+
+Este flujo de n8n recibe un guion, logo y avatar a través de un formulario público y devuelve un video de ~45 segundos con voz en off, música de fondo y escenas generadas automáticamente.
+
+## Resumen de nodos y configuraciones
+
+1. **Formulario Brief (`Form Trigger`)**
+   - Endpoint: `/brief-video-45s`.
+   - Campos: `script` (textarea), `logo` (archivo), `avatar` (archivo).
+   - Define restricciones para formatos (PNG/SVG para logo y JPG/PNG para avatar).
+
+2. **Normalizar Entradas (`Function`)**
+   - Limpia el guion, fija duración objetivo (45 s) y conserva binarios de logo y avatar en propiedades `assets.logo` y `assets.avatar`.
+
+3. **Storyboard IA (`OpenAI Chat`)**
+   - Modelo `gpt-4.1-mini` con formato JSON.
+   - Devuelve 3 escenas (~15 s cada una) con prompts visuales y texto para overlays mencionando logo/avatar cuando aplique.
+
+4. **Expandir Escenas (`Function`)**
+   - Convierte el JSON de escenas en items independientes con la metadata del guion y assets.
+
+5. **Iterar Escenas (`SplitInBatches`)**
+   - Itera cada escena individualmente para generar sus recursos visuales.
+
+6. **Generar Imagen Escena (`HTTP Request` a OpenAI Images)**
+   - Modelo `gpt-image-1`, tamaño 1792×1024.
+   - Prompt: instrucciones del storyboard + recordatorio de espacio para logo/avatar.
+
+7. **Decodificar Imagen (`Move Binary Data`)**
+   - Convierte la respuesta Base64 a binario `sceneImage`.
+
+8. **Preparar Payload Escena (`Function`)**
+   - Calcula duración de escena, conserva overlay text e imagen.
+
+9. **Unir Escenas (`Merge`)**
+   - Recompila todos los items generados, manteniendo el orden según `scene.order`.
+
+10. **Generar Voz en Off (`HTTP Request` a OpenAI TTS)**
+    - Endpoint: `audio/speech` con modelo `gpt-4o-mini-tts`, voz `alloy`, salida MP3.
+
+11. **Buscar Música (`HTTP Request` a Pixabay)**
+    - Filtra por pistas corporativas de 40-60 s.
+
+12. **Seleccionar Pista (`Function`)**
+    - Toma la pista más popular y devuelve `downloadUrl`.
+
+13. **Descargar Música (`HTTP Request`)**
+    - Obtiene el archivo de audio en binario.
+
+14. **Renderizar Video (`Execute Command`)**
+    - Llama un script `scripts/render_video.sh` que usa FFmpeg.
+    - El script debe: 
+      1. Crear clips estáticos por escena aplicando efecto Ken Burns y duración exacta.
+      2. Superponer logo (arriba derecha) y avatar (arriba izquierda o según escena) con transparencia animada.
+      3. Añadir títulos/overlay text por escena con fuente corporativa.
+      4. Sincronizar voz en off con escenas según `start/end`.
+      5. Normalizar niveles de audio, reduciendo música al 30% (-10 dB) durante narración.
+      6. Exportar a `final_video.mp4` (H.264 + AAC, 1920×1080, 25 fps).
+
+15. **Entregar Video (`Respond to Webhook`)**
+    - Devuelve el binario `video` generado por el script como respuesta HTTP (descarga).
+
+## Recomendaciones de coherencia audiovisual
+
+- **Control de duración:** Validar que la suma de duraciones por escena sea ≤ 45 s; si excede, ajustar la última escena mediante `Math.min` dentro del script de render.
+- **Textos y brand assets:** Mantener logo en PNG con transparencia y avatar recortado en círculo dentro del script `render_video.sh` para evitar fondos duros.
+- **Estrategia musical:** Fijar compresión side-chain en FFmpeg (`sidechaincompress`) para que la voz destaque sin perder presencia musical.
+- **Gestión de voz:** Permitir parametrizar voz y tono desde campos opcionales del formulario si se requiere personalización.
+- **Logs y reintentos:** Añadir nodos `Error Trigger` y `IF` para reintentos cuando los servicios externos fallen (OpenAI/Pixabay).
+- **Entrega:** Considerar un nodo adicional `Email` o `Notion` para notificar al usuario con enlace al video alojado en S3 o similar, usando el mismo binario generado.
+
+## Dependencias externas
+
+- **OpenAI** (chat, imágenes, TTS) – requiere credenciales `OPENAI_API_KEY`.
+- **Pixabay Audio API** – requiere `PIXABAY_API_KEY`.
+- **FFmpeg** instalado en el host de n8n y script personalizado en `scripts/render_video.sh`.
+
+## Script de render sugerido
+
+```bash
+#!/bin/bash
+# scripts/render_video.sh
+# Espera JSON por stdin (parámetros `$1`) con rutas temporales creadas por n8n.
+# Se recomienda que n8n cree archivos temporales antes de invocar el script.
+
+set -euo pipefail
+
+# 1. Crear recursos temporales desde binarios
+# 2. Generar timeline y filtros FFmpeg
+# 3. Exportar final_video.mp4 y devolver ruta para que n8n lo lea
+```
+
+Ajusta el script según la infraestructura (docker, volumen compartido, etc.).

--- a/scripts/render_video.sh
+++ b/scripts/render_video.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# render_video.sh
+# Script auxiliar invocado desde n8n para componer video final.
+# Recibe como primer argumento la ruta a un archivo JSON con rutas temporales a assets.
+
+set -euo pipefail
+
+INPUT_PATH=${1:-}
+if [[ -z "$INPUT_PATH" || ! -f "$INPUT_PATH" ]]; then
+  echo "Debe proporcionar la ruta a un JSON de configuración" >&2
+  exit 1
+fi
+
+python3 - "$INPUT_PATH" <<'PYTHON'
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+input_path = sys.argv[1]
+with open(input_path, 'r', encoding='utf-8') as f:
+    payload = json.load(f)
+
+scenes = payload.get('scenes', [])
+voice_over = payload.get('voiceOverPath')
+music = payload.get('musicPath')
+output = payload.get('outputPath', 'final_video.mp4')
+workspace = payload.get('workspace') or os.path.dirname(output) or '.'
+os.makedirs(workspace, exist_ok=True)
+
+scene_files = []
+
+for idx, scene in enumerate(sorted(scenes, key=lambda s: s.get('order', idx))):
+    still = scene.get('imagePath')
+    if not still or not os.path.exists(still):
+        raise FileNotFoundError(f"Imagen de escena no encontrada: {still}")
+    duration = float(scene.get('duration', 15))
+    overlay_text = scene.get('overlayText', '')
+    logo = scene.get('logoPath') if scene.get('logoPath') and os.path.exists(scene.get('logoPath')) else None
+    avatar = scene.get('avatarPath') if scene.get('avatarPath') and os.path.exists(scene.get('avatarPath')) else None
+
+    scene_output = os.path.join(workspace, f"scene_{idx:02d}.mp4")
+
+    filter_parts = ["[0:v]scale=1920:1080,zoompan=z='min(zoom+0.002,1.05)':d=125:s=1920x1080:fps=25[base];"]
+    last_label = '[base]'
+
+    if logo:
+        escaped_logo = logo.replace('\\', '\\\\').replace("'", "\\'")
+        filter_parts.append(f"movie='{escaped_logo}'[logo];{last_label}[logo]overlay=W-w-80:80:enable='between(t,0,{duration})'[base_logo];")
+        last_label = '[base_logo]'
+
+    if avatar:
+        escaped_avatar = avatar.replace('\\', '\\\\').replace("'", "\\'")
+        filter_parts.append(f"movie='{escaped_avatar}'[avatar];{last_label}[avatar]overlay=80:80:enable='between(t,0,{duration})'[base_avatar];")
+        last_label = '[base_avatar]'
+
+    if overlay_text:
+        text = overlay_text.replace('"', '\\"')
+        filter_parts.append(textwrap.dedent(f"""
+            {last_label}drawtext=text={text}:fontcolor=white:fontsize=48:x=(w-text_w)/2:y=h-160:borderw=2:bordercolor=0x000000@0.6[outv]
+        """).strip())
+        last_label = '[outv]'
+
+    if last_label != '[outv]':
+        filter_parts.append(f"{last_label}format=yuv420p[outv]")
+
+    filter_complex = ''.join(filter_parts)
+
+    cmd = [
+        'ffmpeg','-y','-loop','1','-i', still,
+        '-filter_complex', filter_complex,
+        '-t', str(duration),
+        '-pix_fmt', 'yuv420p',
+        '-c:v', 'libx264',
+        '-r', '25',
+        scene_output
+    ]
+
+    subprocess.run(cmd, check=True)
+    scene_files.append(scene_output)
+
+if not scene_files:
+    raise RuntimeError('No se generaron escenas')
+
+concat_list = os.path.join(workspace, 'timeline.txt')
+with open(concat_list, 'w', encoding='utf-8') as f:
+    for path in scene_files:
+        f.write(f"file '{path}'\n")
+
+scene_video = os.path.join(workspace, 'scenes.mp4')
+subprocess.run(['ffmpeg','-y','-f','concat','-safe','0','-i', concat_list,'-c','copy', scene_video], check=True)
+
+if not voice_over or not os.path.exists(voice_over):
+    raise FileNotFoundError('No se encontró archivo de voz en off')
+
+if not music or not os.path.exists(music):
+    raise FileNotFoundError('No se encontró pista musical')
+
+mixed_audio = os.path.join(workspace, 'mix.m4a')
+subprocess.run([
+    'ffmpeg','-y','-i', voice_over,'-i', music,
+    '-filter_complex','[1:a]volume=0.35[a1];[a1][0:a]sidechaincompress=threshold=0.1:ratio=6:attack=5:release=250[bgmduck];[0:a][bgmduck]amix=inputs=2:weights=1 1:normalize=1[aout]',
+    '-map','[aout]','-c:a','aac','-b:a','192k', mixed_audio
+], check=True)
+
+subprocess.run([
+    'ffmpeg','-y','-i', scene_video,'-i', mixed_audio,
+    '-c:v','libx264','-preset','medium','-crf','18',
+    '-c:a','aac','-b:a','192k','-shortest', output
+], check=True)
+
+print(json.dumps({"videoPath": output}))
+PYTHON


### PR DESCRIPTION
## Summary
- add an n8n flow export that collects a script, logo, and avatar to assemble a 45-second video with AI services
- document the workflow configuration and audiovisual recommendations for coherent rendering
- provide an ffmpeg-based render script that stitches generated scenes, applies branding overlays, and mixes voice-over with music

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0eddcc8a48325a5dd492c11fb81aa